### PR TITLE
URL Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ llgo is a compiler for [Go](http://golang.org), written in Go, and using the
 
 llgo is a fledgling, and is being developed primarily as an educational
 exercise. It is not presently useful for real work. Progress will be reported
-at [http://blog.awilkins.id.au](http//blog.awilkins.id.au).
+at [http://blog.awilkins.id.au](http://blog.awilkins.id.au).
 
 # Installation
 


### PR DESCRIPTION
The link to your blog is missing a :, just thought I'd fix it for you.
