### PR TITLE
test/unsafe/pointer.go: fix assumption of 32-bit int

### DIFF
--- a/llgo/testdata/unsafe/pointer.go
+++ b/llgo/testdata/unsafe/pointer.go
@@ -9,7 +9,7 @@ func main() {
     ptr := &i[0]
     println(*ptr)
     ptr_i := unsafe.Pointer(ptr)
-    ptr_i = unsafe.Pointer(uintptr(ptr_i) + 4)
+    ptr_i = unsafe.Pointer(uintptr(ptr_i) + unsafe.Sizeof(i[0]))
     ptr = (*int)(ptr_i)
     println(*ptr)
 }


### PR DESCRIPTION
so that test could pass with Go 1.1.
