### PR TITLE
println.go: change interface{} format string to 0x%x

### DIFF
--- a/println.go
+++ b/println.go
@@ -128,7 +128,7 @@ func (c *compiler) printValues(println_ bool, values ...Value) Value {
 				}
 
 			case *types.Interface:
-				format += "(%p,%p)"
+				format += "(0x%lx,0x%lx)"
 				ival := c.builder.CreateExtractValue(llvm_value, 0, "")
 				itype := c.builder.CreateExtractValue(llvm_value, 1, "")
 				args = append(args, ival)


### PR DESCRIPTION
We shouldn't assume printf("%p") to be eqv. to printf("0x%x"),
because some libc will output "(nil)" for printf("%p", 0), and
this will cause TestRecover to fail.
Instead we should explicitly use "0x%x" to be compatible with
Go's println.

Signed-off-by: minux minux.ma@gmail.com
