### PR TITLE
cmd/llgo-build: add "-work" flag.

### DIFF
--- a/cmd/llgo-build/main.go
+++ b/cmd/llgo-build/main.go
@@ -31,6 +31,7 @@ var (
 	workdir       string
 	test          bool
 	buildDeps     bool = true
+	work          bool
 )
 
 func init() {
@@ -41,6 +42,7 @@ func init() {
 	flag.BoolVar(&printcommands, "x", false, "Print the commands")
 	flag.BoolVar(&test, "test", test, "When specified, the created output binary will be similar to what's output of \"go test -c\"")
 	flag.BoolVar(&buildDeps, "build-deps", buildDeps, "Whether to also build dependency packages or not")
+	flag.BoolVar(&work, "work", work, "Print the name of the temporary work directory and do not delete it when exiting")
 }
 
 func main() {
@@ -74,6 +76,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if work {
+		log.Println("Working directory:", workdir)
+	}
 	args := flag.Args()
 	if test {
 		if len(args) > 1 {
@@ -84,7 +89,9 @@ func main() {
 	} else {
 		err = buildPackages(args)
 	}
-	os.RemoveAll(workdir)
+	if !work {
+		os.RemoveAll(workdir)
+	}
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This is mostly useful to keep the .o file around until there's a
proper solution for #82.
