### PR TITLE
pkg/math/big: Alias functions

### DIFF
--- a/pkg/math/big/arith_decl.go
+++ b/pkg/math/big/arith_decl.go
@@ -1,0 +1,20 @@
+// Copyright 2013 The llgo Authors.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package big
+
+var (
+	mulWW     = mulWW_g
+	divWW     = divWW_g
+	addVV     = addVV_g
+	subVV     = subVV_g
+	addVW     = addVW_g
+	subVW     = subVW_g
+	shlVU     = shlVU_g
+	shrVU     = shrVU_g
+	mulAddVWW = mulAddVWW_g
+	addMulVVW = addMulVVW_g
+	divWVW    = divWVW_g
+	bitLen    = bitLen_g
+)


### PR DESCRIPTION
Apparently aliasing can be done this way too, at least as far as the linker is concerned. 
