### PR TITLE
Fixed handling of nil-literals

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -136,7 +136,7 @@ func (c *compiler) Resolve(ident *ast.Ident) Value {
 		value = c.NewConstValue(obj.Val(), obj.Type())
 
 	default:
-		panic(fmt.Sprintf("unreachable (%T)", obj))
+		panic(fmt.Sprintf("Could not handle type in compiler.Resolve(): (%T)", obj))
 	}
 
 	data.Value = value

--- a/value.go
+++ b/value.go
@@ -56,7 +56,8 @@ func (c *compiler) NewValue(v llvm.Value, t types.Type) *LLVMValue {
 
 func (c *compiler) NewConstValue(v exact.Value, typ types.Type) *LLVMValue {
 	switch {
-	case v.Kind() == exact.Nil:
+	case v.Kind() == exact.Unknown:
+		// TODO nil literals should be represented more appropriately once the exact-package supports it.
 		llvmtyp := c.types.ToLLVM(typ)
 		return c.NewValue(llvm.ConstNull(llvmtyp), typ)
 


### PR DESCRIPTION
Hey there!

This fix seems to bring llgo to a state where it is able to compile the runtime.
Please review thoroughly.

It seems to me that appropriate representation of nil-values is currently missing in the exact-package.
I am using the Basic Kind 'Unknown' to handle that for now.
Another weird thing is that nil-literals are translated to Ident ast-nodes (instead of some kind of constant node).

Cheers,
Anton
