### PR TITLE
Refactor Value/LLVMValue

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-llvm/llvm"
 )
 
-func (fr *frame) callCap(arg *LLVMValue) *LLVMValue {
+func (fr *frame) callCap(arg *govalue) *govalue {
 	var v llvm.Value
 	switch typ := arg.Type().Underlying().(type) {
 	case *types.Array:
@@ -25,7 +25,7 @@ func (fr *frame) callCap(arg *LLVMValue) *LLVMValue {
 	return newValue(v, types.Typ[types.Int])
 }
 
-func (fr *frame) callLen(arg *LLVMValue) *LLVMValue {
+func (fr *frame) callLen(arg *govalue) *govalue {
 	var lenvalue llvm.Value
 	switch typ := arg.Type().Underlying().(type) {
 	case *types.Array:
@@ -49,7 +49,7 @@ func (fr *frame) callLen(arg *LLVMValue) *LLVMValue {
 
 // callAppend takes two slices of the same type, and yields
 // the result of appending the second to the first.
-func (fr *frame) callAppend(a, b *LLVMValue) *LLVMValue {
+func (fr *frame) callAppend(a, b *govalue) *govalue {
 	bptr := fr.builder.CreateExtractValue(b.value, 0, "")
 	blen := fr.builder.CreateExtractValue(b.value, 1, "")
 	elemsizeInt64 := fr.types.Sizeof(a.Type().Underlying().(*types.Slice).Elem())
@@ -60,7 +60,7 @@ func (fr *frame) callAppend(a, b *LLVMValue) *LLVMValue {
 
 // callCopy takes two slices a and b of the same type, and
 // yields the result of calling "copy(a, b)".
-func (fr *frame) callCopy(dest, source *LLVMValue) *LLVMValue {
+func (fr *frame) callCopy(dest, source *govalue) *govalue {
 	aptr := fr.builder.CreateExtractValue(dest.value, 0, "")
 	alen := fr.builder.CreateExtractValue(dest.value, 1, "")
 	bptr := fr.builder.CreateExtractValue(source.value, 0, "")

--- a/call.go
+++ b/call.go
@@ -11,7 +11,7 @@ import (
 
 // createCall emits the code for a function call,
 // taking into account receivers, and panic/defer.
-func (c *compiler) createCall(fn *LLVMValue, argValues []*LLVMValue) []*LLVMValue {
+func (c *compiler) createCall(fn *govalue, argValues []*govalue) []*govalue {
 	fntyp := fn.Type().Underlying().(*types.Signature)
 	typinfo := c.types.getSignatureInfo(fntyp)
 
@@ -21,7 +21,7 @@ func (c *compiler) createCall(fn *LLVMValue, argValues []*LLVMValue) []*LLVMValu
 	}
 	results := typinfo.call(c.types.ctx, c.allocaBuilder, c.builder, fn.value, args)
 
-	resultValues := make([]*LLVMValue, len(results))
+	resultValues := make([]*govalue, len(results))
 	for i, res := range results {
 		resultValues[i] = newValue(res, fntyp.Results().At(i).Type())
 	}

--- a/closures.go
+++ b/closures.go
@@ -13,24 +13,24 @@ import (
 // makeClosure creates a closure from a function pointer and
 // a set of bindings. The bindings are addresses of captured
 // variables.
-func (c *compiler) makeClosure(fn *LLVMValue, bindings []*LLVMValue) *LLVMValue {
+func (c *compiler) makeClosure(fn *govalue, bindings []*govalue) *govalue    {
 	/*
-	types := make([]llvm.Type, len(bindings))
-	for i, binding := range bindings {
-		types[i] = c.types.ToLLVM(binding.Type())
-	}
-	block := c.createTypeMalloc(llvm.StructType(types, false))
-	for i, binding := range bindings {
-		addressPtr := c.builder.CreateStructGEP(block, i, "")
-		c.builder.CreateStore(binding.LLVMValue(), addressPtr)
-	}
-	block = c.builder.CreateBitCast(block, llvm.PointerType(llvm.Int8Type(), 0), "")
-	// fn is a raw function pointer; ToLLVM yields {*fn, *uint8}.
-	closure := llvm.Undef(c.types.ToLLVM(fn.Type()))
-	fnptr := c.builder.CreateBitCast(fn.LLVMValue(), closure.Type().StructElementTypes()[0], "")
-	closure = c.builder.CreateInsertValue(closure, fnptr, 0, "")
-	closure = c.builder.CreateInsertValue(closure, block, 1, "")
-	return newValue(closure, fn.Type())
+		types := make([]llvm.Type, len(bindings))
+		for i, binding := range bindings {
+			types[i] = c.types.ToLLVM(binding.Type())
+		}
+		block := c.createTypeMalloc(llvm.StructType(types, false))
+		for i, binding := range bindings {
+			addressPtr := c.builder.CreateStructGEP(block, i, "")
+			c.builder.CreateStore(binding.LLVMValue(), addressPtr)
+		}
+		block = c.builder.CreateBitCast(block, llvm.PointerType(llvm.Int8Type(), 0), "")
+		// fn is a raw function pointer; ToLLVM yields {*fn, *uint8}.
+		closure := llvm.Undef(c.types.ToLLVM(fn.Type()))
+		fnptr := c.builder.CreateBitCast(fn.LLVMValue(), closure.Type().StructElementTypes()[0], "")
+		closure = c.builder.CreateInsertValue(closure, fnptr, 0, "")
+		closure = c.builder.CreateInsertValue(closure, block, 1, "")
+		return newValue(closure, fn.Type())
 	*/
 	return nil
 }

--- a/indirect.go
+++ b/indirect.go
@@ -18,7 +18,7 @@ func (fr *frame) createThunk(call *ssa.CallCommon) (thunk llvm.Value, arg llvm.V
 	var nonconstindices []int
 	var nonconsttypes []*types.Var
 	var args []llvm.Value
-	packArg := func(arg *LLVMValue) {
+	packArg := func(arg *govalue) {
 		if arg.value.IsAConstant().C != nil {
 			args = append(args, arg.value)
 		} else {

--- a/println.go
+++ b/println.go
@@ -10,7 +10,7 @@ import (
 	"code.google.com/p/go.tools/go/types"
 )
 
-func (fr *frame) printValues(println_ bool, values ...*LLVMValue) {
+func (fr *frame) printValues(println_ bool, values ...*govalue) {
 	for i, value := range values {
 		llvm_value := value.value
 

--- a/runtime.go
+++ b/runtime.go
@@ -18,7 +18,7 @@ import (
 )
 
 type FuncResolver interface {
-	ResolveFunc(*types.Func) *LLVMValue
+	ResolveFunc(*types.Func) *govalue
 }
 
 type runtimeType struct {
@@ -50,7 +50,7 @@ type runtimeInterface struct {
 	selectinit,
 	selectrecv,
 	selectsend,
-	selectsize *LLVMValue
+	selectsize *govalue
 
 	// LLVM intrinsics
 	memcpy,
@@ -106,7 +106,7 @@ type runtimeInterface struct {
 
 func newRuntimeInterface(pkg *types.Package, module llvm.Module, tm *llvmTypeMap, fr FuncResolver) (*runtimeInterface, error) {
 	var ri runtimeInterface
-	intrinsics := map[string]**LLVMValue{
+	intrinsics := map[string]**govalue{
 		"selectdefault": &ri.selectdefault,
 		"selectgo":      &ri.selectgo,
 		"selectinit":    &ri.selectinit,

--- a/slice.go
+++ b/slice.go
@@ -11,7 +11,7 @@ import (
 
 // makeSlice allocates a new slice with the optional length and capacity,
 // initialising its contents to their zero values.
-func (fr *frame) makeSlice(sliceType types.Type, length, capacity *LLVMValue) *LLVMValue {
+func (fr *frame) makeSlice(sliceType types.Type, length, capacity *govalue) *govalue {
 	length = fr.convert(length, types.Typ[types.Uintptr])
 	capacity = fr.convert(capacity, types.Typ[types.Uintptr])
 	runtimeType := fr.types.ToRuntime(sliceType)
@@ -34,7 +34,7 @@ func (c *compiler) coerceSlice(src llvm.Value, dsttyp llvm.Type) llvm.Value {
 	return dst
 }
 
-func (fr *frame) slice(x, low, high *LLVMValue) *LLVMValue {
+func (fr *frame) slice(x, low, high *govalue) *govalue {
 	var lowval, highval llvm.Value
 	if low != nil {
 		lowval = fr.convert(low, types.Typ[types.Int]).value

--- a/strings.go
+++ b/strings.go
@@ -19,12 +19,12 @@ func (c *compiler) coerceString(v llvm.Value, typ llvm.Type) llvm.Value {
 	return result
 }
 
-func (fr *frame) concatenateStrings(lhs, rhs *LLVMValue) *LLVMValue {
+func (fr *frame) concatenateStrings(lhs, rhs *govalue) *govalue {
 	result := fr.runtime.stringPlus.call(fr, lhs.value, rhs.value)
 	return newValue(result[0], types.Typ[types.String])
 }
 
-func (fr *frame) compareStrings(lhs, rhs *LLVMValue, op token.Token) *LLVMValue {
+func (fr *frame) compareStrings(lhs, rhs *govalue, op token.Token) *govalue {
 	result := fr.runtime.strcmp.call(fr, lhs.value, rhs.value)[0]
 	zero := llvm.ConstNull(fr.types.inttype)
 	var pred llvm.IntPredicate
@@ -40,7 +40,7 @@ func (fr *frame) compareStrings(lhs, rhs *LLVMValue, op token.Token) *LLVMValue 
 	case token.GEQ:
 		pred = llvm.IntSGE
 	case token.NEQ:
-		panic("NEQ is handled in LLVMValue.BinaryOp")
+		panic("NEQ is handled in govalue.BinaryOp")
 	default:
 		panic("unreachable")
 	}
@@ -50,20 +50,20 @@ func (fr *frame) compareStrings(lhs, rhs *LLVMValue, op token.Token) *LLVMValue 
 }
 
 // stringIndex implements v = m[i]
-func (c *compiler) stringIndex(s, i *LLVMValue) *LLVMValue {
+func (c *compiler) stringIndex(s, i *govalue) *govalue {
 	ptr := c.builder.CreateExtractValue(s.value, 0, "")
 	ptr = c.builder.CreateGEP(ptr, []llvm.Value{i.value}, "")
 	return newValue(c.builder.CreateLoad(ptr, ""), types.Typ[types.Byte])
 }
 
-func (fr *frame) stringIterInit(str *LLVMValue) []*LLVMValue {
+func (fr *frame) stringIterInit(str *govalue) []*govalue {
 	indexptr := fr.allocaBuilder.CreateAlloca(fr.types.inttype, "")
 	fr.builder.CreateStore(llvm.ConstNull(fr.types.inttype), indexptr)
-	return []*LLVMValue{str, newValue(indexptr, types.Typ[types.Int])}
+	return []*govalue{str, newValue(indexptr, types.Typ[types.Int])}
 }
 
 // stringIterNext advances the iterator, and returns the tuple (ok, k, v).
-func (fr *frame) stringIterNext(iter []*LLVMValue) []*LLVMValue {
+func (fr *frame) stringIterNext(iter []*govalue) []*govalue {
 	str, indexptr := iter[0], iter[1]
 	k := fr.builder.CreateLoad(indexptr.value, "")
 
@@ -73,22 +73,22 @@ func (fr *frame) stringIterNext(iter []*LLVMValue) []*LLVMValue {
 	ok = fr.builder.CreateZExt(ok, llvm.Int8Type(), "")
 	v := result[1]
 
-	return []*LLVMValue{newValue(ok, types.Typ[types.Bool]), newValue(k, types.Typ[types.Int]), newValue(v, types.Typ[types.Rune])}
+	return []*govalue{newValue(ok, types.Typ[types.Bool]), newValue(k, types.Typ[types.Int]), newValue(v, types.Typ[types.Rune])}
 }
 
-func (fr *frame) runeToString(v *LLVMValue) *LLVMValue {
+func (fr *frame) runeToString(v *govalue) *govalue {
 	v = fr.convert(v, types.Typ[types.Int])
 	result := fr.runtime.intToString.call(fr, v.value)
 	return newValue(result[0], types.Typ[types.String])
 }
 
-func (fr *frame) stringToRuneSlice(v *LLVMValue) *LLVMValue {
+func (fr *frame) stringToRuneSlice(v *govalue) *govalue {
 	result := fr.runtime.stringToIntArray.call(fr, v.value)
 	runeslice := types.NewSlice(types.Typ[types.Rune])
 	return newValue(result[0], runeslice)
 }
 
-func (fr *frame) runeSliceToString(v *LLVMValue) *LLVMValue {
+func (fr *frame) runeSliceToString(v *govalue) *govalue {
 	llv := v.value
 	ptr := fr.builder.CreateExtractValue(llv, 0, "")
 	len := fr.builder.CreateExtractValue(llv, 1, "")

--- a/typemap.go
+++ b/typemap.go
@@ -17,7 +17,7 @@ import (
 )
 
 type MethodResolver interface {
-	ResolveMethod(*types.Selection) *LLVMValue
+	ResolveMethod(*types.Selection) *govalue
 }
 
 // llvmTypeMap is provides a means of mapping from a types.Map

--- a/utils.go
+++ b/utils.go
@@ -16,7 +16,7 @@ func (fns byName) Less(i, j int) bool {
 	return fns[i].Name() < fns[j].Name()
 }
 
-func (fr *frame) loadOrNull(cond, ptr llvm.Value, ty types.Type) *LLVMValue {
+func (fr *frame) loadOrNull(cond, ptr llvm.Value, ty types.Type) *govalue {
 	startbb := fr.builder.GetInsertBlock()
 	loadbb := llvm.AddBasicBlock(fr.function, "")
 	contbb := llvm.AddBasicBlock(fr.function, "")


### PR DESCRIPTION
Only one thing remains to be done, and that's remove the Type method from govalue (nee LLVMValue).

I'm not married to the name "govalue", happy to discuss alternatives. It was originally named LLVMValue to distinguish from the then-present ConstValue, which produced an LLVM value on demand (hence the LLVMValue method). Being called LLVMValue belies the fact that it also has a Go type.
