### PR TITLE
Don't parse runtime package

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -53,6 +53,8 @@ type selectState struct {
 }
 
 func (fr *frame) chanSelect(states []selectState, blocking bool) *govalue {
+    panic("chanSelect not implemented")
+    /*
 	stackptr := fr.stacksave()
 	defer fr.stackrestore(stackptr)
 
@@ -124,4 +126,5 @@ func (fr *frame) chanSelect(states []selectState, blocking bool) *govalue {
 	tuple := fr.builder.CreateLoad(tupleptr, "")
 	tuple = fr.builder.CreateInsertValue(tuple, index, 0, "")
 	return newValue(tuple, resType)
+    */
 }

--- a/ssa.go
+++ b/ssa.go
@@ -79,11 +79,6 @@ func (u *unit) ResolveMethod(s *types.Selection) *govalue {
 	return u.resolveFunction(u.pkg.Prog.Method(s))
 }
 
-// ResolveFunc implements FuncResolver.ResolveFunc.
-func (u *unit) ResolveFunc(f *types.Func) *govalue {
-	return u.resolveFunction(u.pkg.Prog.FuncValue(f))
-}
-
 func (u *unit) resolveFunction(f *ssa.Function) *govalue {
 	llvmFunction := u.resolveFunctionGlobal(f)
 	return newValue(llvm.ConstBitCast(llvmFunction, llvm.PointerType(llvm.Int8Type(), 0)), f.Signature)


### PR DESCRIPTION
Dropped parsing of the runtime package, and commented out the body of chanSelect. Also removed now-unreferenced stacksave/stackrestore and FuncResolver/ResolveFunc.
