### PR TITLE
Explicitly pass the type of the operand to fr.makeInterface

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -66,16 +66,15 @@ func (fr *frame) compareInterfaces(a, b *govalue) *govalue {
 	return newValue(result, types.Typ[types.Bool])
 }
 
-func (fr *frame) makeInterface(v *govalue, iface types.Type) *govalue {
-	llv := v.value
+func (fr *frame) makeInterface(llv llvm.Value, vty types.Type, iface types.Type) *govalue {
 	i8ptr := llvm.PointerType(llvm.Int8Type(), 0)
-	if _, ok := v.Type().Underlying().(*types.Pointer); !ok {
-		ptr := fr.createTypeMalloc(v.Type())
+	if _, ok := vty.Underlying().(*types.Pointer); !ok {
+		ptr := fr.createTypeMalloc(vty)
 		fr.builder.CreateStore(llv, ptr)
 		llv = fr.builder.CreateBitCast(ptr, i8ptr, "")
 	}
 	value := llvm.Undef(fr.types.ToLLVM(iface))
-	itab := fr.types.getItabPointer(v.Type(), iface.Underlying().(*types.Interface))
+	itab := fr.types.getItabPointer(vty, iface.Underlying().(*types.Interface))
 	value = fr.builder.CreateInsertValue(value, itab, 0, "")
 	value = fr.builder.CreateInsertValue(value, llv, 1, "")
 	return newValue(value, iface)

--- a/ssa.go
+++ b/ssa.go
@@ -665,8 +665,8 @@ func (fr *frame) instruction(instr ssa.Instruction) {
 		fr.env[instr] = fr.makeClosure(fn, bindings)
 
 	case *ssa.MakeInterface:
-		receiver := fr.value(instr.X)
-		fr.env[instr] = fr.makeInterface(receiver, instr.Type())
+		receiver := fr.value(instr.X).value
+		fr.env[instr] = fr.makeInterface(receiver, instr.X.Type(), instr.Type())
 
 	case *ssa.MakeMap:
 		fr.env[instr] = fr.makeMap(instr.Type(), fr.value(instr.Reserve))


### PR DESCRIPTION
I was seeing some panics caused by makeInterface being called with the wrong
type. Rather than try to fix those, I decided to take a step on the long
path of removing the typ field from govalue by passing the value and its
type into makeInterface separately.
