### PR TITLE
Bitcast pointer to correct type before icmp

### DIFF
--- a/llgo/testdata/operators/basics.go
+++ b/llgo/testdata/operators/basics.go
@@ -1,5 +1,7 @@
 package main
 
+var global string
+
 var hi = 0xFF00
 var lo = 0xFF00
 
@@ -35,7 +37,7 @@ func main() {
 	// operand of the shift expression.
 	shift := uint(2)
 	println(uint64(0xFFFFFFFF) & (1<<shift - 1))
-	println((1<<shift -1) & uint64(0xFFFFFFFF))
+	println((1<<shift - 1) & uint64(0xFFFFFFFF))
 
 	// rhs' type is converted lhs'
 	println(uint32(1) << uint64(2))
@@ -66,4 +68,7 @@ func main() {
 	var e uint = 40
 	x &^= 1<<(64-12-e) - 1
 	println(x)
+
+	// compare global to non-global
+	println(new(string) == &global)
 }


### PR DESCRIPTION
Pointers may not have the same backend type.
For example, ToLLVM yield *i8 regardless of
the underlying type; globals have type *T,
where T is the source type.
