### PR TITLE
Fix map range in conjunction with defer

### DIFF
--- a/llgo/testdata/maps/range.go
+++ b/llgo/testdata/maps/range.go
@@ -1,6 +1,7 @@
 package main
 
 func main() {
+	defer println("done")
 	m := make(map[int]int)
 	m[0] = 3
 	m[1] = 4

--- a/maps.go
+++ b/maps.go
@@ -119,6 +119,7 @@ func (fr *frame) mapIterNext(iter []*govalue) []*govalue {
 
 	fr.builder.SetInsertPointAtEnd(loadbb)
 	fr.runtime.mapiter2.call(fr, mapiterbufelem0ptr, keyptr, valptr)
+	loadbb = fr.builder.GetInsertBlock()
 	loadedkey := fr.builder.CreateLoad(keybuf, "")
 	loadedval := fr.builder.CreateLoad(valbuf, "")
 	fr.builder.CreateBr(cont2bb)


### PR DESCRIPTION
Predecessor block is wrong for map range phi node when the containing function contains defer call.
