### PR TITLE
Use __go_receive instead of __go_receive_big

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -39,7 +39,7 @@ func (fr *frame) chanRecv(ch *govalue, commaOk bool) (x, ok *govalue) {
 		okval := fr.runtime.chanrecv2.call(fr, chantyp, ch.value, ptri8)[0]
 		ok = newValue(okval, types.Typ[types.Bool])
 	} else {
-		fr.runtime.receiveBig.call(fr, chantyp, ch.value, ptri8)
+		fr.runtime.receive.call(fr, chantyp, ch.value, ptri8)
 	}
 	x = newValue(fr.builder.CreateLoad(ptr, ""), elemtyp)
 	return

--- a/runtime.go
+++ b/runtime.go
@@ -98,7 +98,7 @@ type runtimeInterface struct {
 	printSpace,
 	printString,
 	printUint64,
-	receiveBig,
+	receive,
 	recover,
 	registerGcRoots,
 	runtimeError,
@@ -386,8 +386,8 @@ func newRuntimeInterface(module llvm.Module, tm *llvmTypeMap) (*runtimeInterface
 			args: []types.Type{Int64},
 		},
 		{
-			name: "__go_receive_big",
-			rfi:  &ri.receiveBig,
+			name: "__go_receive",
+			rfi:  &ri.receive,
 			args: []types.Type{UnsafePointer, UnsafePointer, UnsafePointer},
 		},
 		{


### PR DESCRIPTION
This runtime function was renamed in the libgo shipped with gcc 4.9.

We may want to consider allowing for multiple versions of libgo, but it may
be easier to closely track gofrontend trunk as we do with LLVM.
