### PR TITLE
Emit more entities in a deterministic order, and do so unconditionally

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -57,10 +57,6 @@ type CompilerOptions struct {
 	// Logger is a logger used for tracing compilation.
 	Logger *log.Logger
 
-	// OrderedCompilation attempts to do some sorting to compile
-	// functions in a deterministic order
-	OrderedCompilation bool
-
 	// DumpSSA is a debugging option that dumps each SSA function
 	// to stderr before generating code for it.
 	DumpSSA bool

--- a/llgo/llgo.go
+++ b/llgo/llgo.go
@@ -194,9 +194,6 @@ func initCompiler() (*llgo.Compiler, error) {
 	if *trace || os.Getenv("LLGO_TRACE") == "1" {
 		opts.Logger = log.New(os.Stderr, "", 0)
 	}
-	if os.Getenv("LLGO_ORDERED_COMPILATION") == "1" {
-		opts.OrderedCompilation = true
-	}
 	opts.GenerateDebug = *generateDebug
 	opts.GccgoPath = *gccgoPath
 	opts.ImportPaths = []string(importpaths)

--- a/ssa.go
+++ b/ssa.go
@@ -43,13 +43,55 @@ func newUnit(c *compiler, pkg *ssa.Package) *unit {
 	return u
 }
 
+type byMemberName []ssa.Member
+
+func (ms byMemberName) Len() int { return len(ms) }
+func (ms byMemberName) Swap(i, j int) {
+	ms[i], ms[j] = ms[j], ms[i]
+}
+func (ms byMemberName) Less(i, j int) bool {
+	return ms[i].Name() < ms[j].Name()
+}
+
+type byFunctionString []*ssa.Function
+
+func (fns byFunctionString) Len() int { return len(fns) }
+func (fns byFunctionString) Swap(i, j int) {
+	fns[i], fns[j] = fns[j], fns[i]
+}
+func (fns byFunctionString) Less(i, j int) bool {
+	return fns[i].String() < fns[j].String()
+}
+
+// Emit functions in order of their fully qualified names. This is so that a
+// bootstrap build can be verified by comparing the stage2 and stage3 binaries.
+func (u *unit) defineFunctionsInOrder(functions map[*ssa.Function]bool) {
+	fns := []*ssa.Function{}
+	for f, _ := range functions {
+		fns = append(fns, f)
+	}
+	sort.Sort(byFunctionString(fns))
+	for _, f := range fns {
+		u.defineFunction(f)
+	}
+}
+
 // translatePackage translates an *ssa.Package into an LLVM module, and returns
 // the translation unit information.
 func (u *unit) translatePackage(pkg *ssa.Package) {
+	ms := make([]ssa.Member, len(pkg.Members))
+	i := 0
+	for _, m := range pkg.Members {
+		ms[i] = m
+		i++
+	}
+
+	sort.Sort(byMemberName(ms))
+
 	// Initialize global storage and type descriptors for this package.
 	// We must create globals regardless of whether they're referenced,
 	// hence the duplication in frame.value.
-	for _, m := range pkg.Members {
+	for _, m := range ms {
 		switch v := m.(type) {
 		case *ssa.Global:
 			llelemtyp := u.llvmtypes.ToLLVM(deref(v.Type()))
@@ -63,22 +105,7 @@ func (u *unit) translatePackage(pkg *ssa.Package) {
 	}
 
 	// Define functions.
-	// Sort if flag is set for deterministic behaviour (for debugging)
-	functions := ssautil.AllFunctions(pkg.Prog)
-	if !u.compiler.OrderedCompilation {
-		for f, _ := range functions {
-			u.defineFunction(f)
-		}
-	} else {
-		fns := []*ssa.Function{}
-		for f, _ := range functions {
-			fns = append(fns, f)
-		}
-		sort.Sort(byName(fns))
-		for _, f := range fns {
-			u.defineFunction(f)
-		}
-	}
+	u.defineFunctionsInOrder(ssautil.AllFunctions(pkg.Prog))
 
 	// Emit initializers for type descriptors, which may trigger
 	// the resolution of additional functions.
@@ -86,9 +113,7 @@ func (u *unit) translatePackage(pkg *ssa.Package) {
 
 	// Define remaining functions that were resolved during
 	// runtime type mapping, but not defined.
-	for f, _ := range u.undefinedFuncs {
-		u.defineFunction(f)
-	}
+	u.defineFunctionsInOrder(u.undefinedFuncs)
 }
 
 // ResolveMethod implements MethodResolver.ResolveMethod.

--- a/utils.go
+++ b/utils.go
@@ -1,20 +1,9 @@
 package llgo
 
 import (
-	"code.google.com/p/go.tools/go/ssa"
 	"code.google.com/p/go.tools/go/types"
 	"github.com/go-llvm/llvm"
 )
-
-type byName []*ssa.Function
-
-func (fns byName) Len() int { return len(fns) }
-func (fns byName) Swap(i, j int) {
-	fns[i], fns[j] = fns[j], fns[i]
-}
-func (fns byName) Less(i, j int) bool {
-	return fns[i].Name() < fns[j].Name()
-}
 
 func (fr *frame) loadOrNull(cond, ptr llvm.Value, ty types.Type) *govalue {
 	startbb := fr.builder.GetInsertBlock()


### PR DESCRIPTION
The cost of doing so is small, and not enough to justify the burden of
maintaining two code paths, in my opinion. By emitting in a deterministic
order, we can check (and indeed, I have checked) the correctness of a
self-hosted build by comparing the second and third stages.
