### PR TITLE
Store FreeVar govalues correctly

### DIFF
--- a/llgo/function_test.go
+++ b/llgo/function_test.go
@@ -10,6 +10,7 @@ func TestMethodSelectors(t *testing.T)   { checkOutputEqual(t, "methods/selector
 func TestNilReceiverMethod(t *testing.T) { checkOutputEqual(t, "methods/nilrecv.go") }
 func TestMethodValues(t *testing.T)      { checkOutputEqual(t, "methods/methodvalues.go") }
 func TestClosure(t *testing.T)           { checkOutputEqual(t, "closures/basic.go") }
+func TestClosureIssue176(t *testing.T)   { checkOutputEqual(t, "closures/issue176.go") }
 func TestCompare(t *testing.T)           { checkOutputEqual(t, "functions/compare.go") }
 func TestMultiValueCall(t *testing.T)    { checkOutputEqual(t, "functions/multivalue.go") }
 func TestUnreachableCode(t *testing.T)   { checkOutputEqual(t, "functions/unreachable.go") }

--- a/llgo/testdata/closures/issue176.go
+++ b/llgo/testdata/closures/issue176.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	a := false
+	f := func() {
+		make(chan *bool, 1) <- &a
+	}
+	f()
+	println(a)
+}

--- a/ssa.go
+++ b/ssa.go
@@ -302,7 +302,7 @@ func (u *unit) defineFunction(f *ssa.Function) {
 		for i, fv := range f.FreeVars {
 			ptr := fr.builder.CreateStructGEP(closure, i+1, "")
 			ptr = fr.builder.CreateLoad(ptr, "")
-			fr.env[fv] = newValue(ptr, types.NewPointer(fv.Type()))
+			fr.env[fv] = newValue(ptr, fv.Type())
 		}
 	}
 


### PR DESCRIPTION
FreeVars have the right (pointer) type to begin with, so we should not explicitly create a pointer type.

Fixes #176
