### PR TITLE
Teach analyze.R to tolerate zeros in the benchmark output

### DIFF
--- a/utils/benchcomp/analyze.R
+++ b/utils/benchcomp/analyze.R
@@ -1,8 +1,10 @@
 sc <- read.table(file('stdin'))
+scratio <- sc$V2 / sc$V3
+scratio <- scratio[scratio > 0]
 
 # Take the log of the ratio. Our null hypothesis is a normal distribution
 # around zero.
-tt <- t.test(log(sc$V2 / sc$V3))
+tt <- t.test(log(scratio))
 tt
 
 # This gives us the geo-mean as we are taking the exponent of the linear mean


### PR DESCRIPTION
GCC can apparently execute some benchmarks in 0.00 ns/op, probably by means
of eliminating the benchmark loop. This caused problems for our R script
because it takes the log of the ratio, and of course log(0) = -Inf. This
change simply modifies the script to ignore zeros in its input.
