### PR TITLE
Roll libbacktrace to r210256

### DIFF
--- a/update_libgo.sh
+++ b/update_libgo.sh
@@ -9,7 +9,7 @@ gofrontendrepo=https://code.google.com/p/gofrontend/
 gofrontendrev=c63d4fe75597
 
 gccrepo=svn://gcc.gnu.org/svn/gcc/trunk
-gccrev=209880
+gccrev=210256
 
 workdir=$llgodir/workdir
 gofrontenddir=$workdir/gofrontend


### PR DESCRIPTION
This incorporates a bug fix for large binaries with lots of debug info.
