### PR TITLE
Apply globaldce at -O0 to remove references (via descriptor) to dead fun...

### DIFF
--- a/cmd/gllgo/gllgo.go
+++ b/cmd/gllgo/gllgo.go
@@ -445,6 +445,12 @@ func runPasses(opts *driverOptions, tm llvm.TargetMachine, m llvm.Module) {
 	pmb.Populate(mpm)
 	pmb.PopulateFunc(fpm)
 
+	if opts.optLevel == 0 {
+		// Remove references (via the descriptor) to dead functions,
+		// for compatibility with other compilers.
+		mpm.AddGlobalDCEPass()
+	}
+
 	opts.sanitizer.addPasses(mpm, fpm)
 
 	fpm.InitializeFunc()

--- a/test/gllgo/dead.go
+++ b/test/gllgo/dead.go
@@ -1,0 +1,6 @@
+// RUN: llgo -O0 -S -o - %s | FileCheck %s
+
+package gotest
+
+// CHECK-NOT: deadfunc
+func deadfunc()


### PR DESCRIPTION
...ctions

This fixes the libgo build at -O0. This also seems generally useful for
compatibility with other compilers.
