### PR TITLE
Use compilation unit as struct scope in debug info

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -318,7 +318,7 @@ func (d *DIBuilder) descriptorStruct(t *types.Struct, name string) llvm.Value {
 	for i, f := range fields {
 		// TODO(axw) file/line where member is defined.
 		t := f.Type()
-		members[i] = d.builder.CreateMemberType(d.scope(), llvm.DIMemberType{
+		members[i] = d.builder.CreateMemberType(d.cu, llvm.DIMemberType{
 			Name:         f.Name(),
 			Type:         d.DIType(t),
 			SizeInBits:   uint64(d.sizes.Sizeof(t) * 8),
@@ -327,7 +327,7 @@ func (d *DIBuilder) descriptorStruct(t *types.Struct, name string) llvm.Value {
 		})
 	}
 	// TODO(axw) file/line where struct is defined.
-	return d.builder.CreateStructType(d.scope(), llvm.DIStructType{
+	return d.builder.CreateStructType(d.cu, llvm.DIStructType{
 		Name:        name,
 		SizeInBits:  uint64(d.sizes.Sizeof(t) * 8),
 		AlignInBits: uint64(d.sizes.Alignof(t) * 8),


### PR DESCRIPTION
It is incorrect to use d.scope() here because type descriptors are cached,
so the resulting struct type will refer to the scope in which we happen to
see the struct type for the first time.

This also works around an assertion failure in LLVM's code generator that
can occur when a struct type's scope is a lexical block.

I had trouble minimising a test case for this, but it can be reproduced
by building the package "launchpad.net/gozk".
