### PR TITLE
Replace '.' character with '_' in package path mangling

### DIFF
--- a/irgen/typemap.go
+++ b/irgen/typemap.go
@@ -483,7 +483,9 @@ func (ctx *manglerContext) mangleSignature(s *types.Signature, recv *types.Var, 
 }
 
 func (ctx *manglerContext) manglePackagePath(pkgpath string, b *bytes.Buffer) {
-	b.WriteString(strings.Replace(pkgpath, "/", "_", -1))
+	pkgpath = strings.Replace(pkgpath, "/", "_", -1)
+	pkgpath = strings.Replace(pkgpath, ".", "_", -1)
+	b.WriteString(pkgpath)
 }
 
 func (ctx *manglerContext) mangleType(t types.Type, b *bytes.Buffer) {

--- a/test/irgen/mangling.go
+++ b/test/irgen/mangling.go
@@ -1,0 +1,7 @@
+// RUN: llgo -fgo-pkgpath=llvm.org/llvm -S -emit-llvm -o - %s | FileCheck %s
+
+package llvm
+
+// CHECK: @llvm_org_llvm.F
+func F() {
+}


### PR DESCRIPTION
Without this change, LLVM will confuse functions in package paths that begin
with 'llvm.', such as the new location of the LLVM bindings, with intrinsics.
