### PR TITLE
Give anonymous functions a mangled name prefix

### DIFF
--- a/irgen/typemap.go
+++ b/irgen/typemap.go
@@ -648,7 +648,7 @@ func (ctx *manglerContext) mangleFunctionName(f *ssa.Function) string {
 	if f.Parent() != nil {
 		// Anonymous functions are not guaranteed to
 		// have unique identifiers at the global scope.
-		b.WriteString(f.Parent().String())
+		b.WriteString(ctx.mangleFunctionName(f.Parent()))
 		b.WriteRune(':')
 		b.WriteString(f.String())
 		return b.String()


### PR DESCRIPTION
The issue that #218 tried to fix still affected anonymous functions, as the
String() method may return a string that begins with 'llvm.'. To avoid this
problem, mangle all such functions with a name prefix of '__anon_'.
